### PR TITLE
Remove "gypsy" from adjs.json

### DIFF
--- a/data/words/adjs.json
+++ b/data/words/adjs.json
@@ -376,7 +376,6 @@
       "grudging",
       "guaranteed",
       "gusty",
-      "gypsy",
       "half-breed",
       "hand-held",
       "handheld",


### PR DESCRIPTION
It's used as a racial slur more often than not (see http://gypsyappropriations.blogspot.com/2010/04/problem-with-word-gypsy.html), and is just grating to me to see in this (great and otherwise respectful!) list of words. Hope you'll consider this pull request.